### PR TITLE
fix: 修正第 4 章翻译格式问题

### DIFF
--- a/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.2.-ruan-jian-an-zhuang-de-gai-shu.md
+++ b/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.2.-ruan-jian-an-zhuang-de-gai-shu.md
@@ -31,7 +31,7 @@ FreeBSD 包包含应用程序的所有命令的预编译副本，以及任何配
 * 有些人不信任二进制分发，或更愿意通过源代码查找潜在问题。
 * 应用自定义补丁时需要源代码。
 
-要跟踪更新的 Port，可以订阅 [FreeBSD  Ports 邮件列表](https://lists.freebsd.org/subscription/freebsd-ports) 和 [FreeBSD  Ports 错误邮件列表](https://lists.freebsd.org/subscription/freebsd-ports-bugs)。
+要跟踪更新的 Port，可以订阅 [FreeBSD Ports 邮件列表](https://lists.freebsd.org/subscription/freebsd-ports) 和 [FreeBSD Ports 错误邮件列表](https://lists.freebsd.org/subscription/freebsd-ports-bugs)。
 
 >**警告**
 >

--- a/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.4.-shi-yong-pkg-jin-hang-er-jin-zhi-bao-guan-li.md
+++ b/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.4.-shi-yong-pkg-jin-hang-er-jin-zhi-bao-guan-li.md
@@ -6,7 +6,7 @@
 
 然而，对于从源代码构建软件的站点，需要一个单独的 [Ports 管理工具](https://docs.freebsd.org/en/books/handbook/ports/#ports-upgrading-tools)。
 
-由于 [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&format=html) 只与二进制包一起使用，它不能替代这些工具。那些工具可以用来从二进制包和 Ports  安装软件，而 [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&format=html) 只安装二进制包。
+由于 [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&format=html) 只与二进制包一起使用，它不能替代这些工具。那些工具可以用来从二进制包和 Ports 安装软件，而 [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&format=html) 只安装二进制包。
 
 ## 4.4.1. 开始使用 pkg
 
@@ -428,7 +428,7 @@ security/sudo
 
 ## 4.4.14. 修改软件包元数据
 
-FreeBSD Ports  中的软件包可能会发生重大版本号变化。为了解决这个问题，pkg 提供了一个内置命令来更新软件包的来源。这个功能在例如将 [lang/python3](https://cgit.freebsd.org/ports/tree/lang/python3/) 重命名为 [lang/python311](https://cgit.freebsd.org/ports/tree/lang/python311/) 时非常有用，这样 [lang/python3](https://cgit.freebsd.org/ports/tree/lang/python3/) 就可以代表版本 `3.11`。
+FreeBSD Ports 中的软件包可能会发生重大版本号变化。为了解决这个问题，pkg 提供了一个内置命令来更新软件包的来源。这个功能在例如将 [lang/python3](https://cgit.freebsd.org/ports/tree/lang/python3/) 重命名为 [lang/python311](https://cgit.freebsd.org/ports/tree/lang/python311/) 时非常有用，这样 [lang/python3](https://cgit.freebsd.org/ports/tree/lang/python3/) 就可以代表版本 `3.11`。
 
 要更改上述示例中的软件包来源，可以运行：
 

--- a/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.5.-shi-yong-ports.md
+++ b/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.5.-shi-yong-ports.md
@@ -1,6 +1,6 @@
 # 4.5.使用 Ports
 
-Ports 是一组 `Makefile`、补丁和描述文件的。每一组文件用于在 FreeBSD 上编译并安装某个独立应用程序，被称为一个 *port*。
+Ports 是一组 `Makefile`、补丁和描述文件。每一组文件用于在 FreeBSD 上编译并安装某个独立应用程序，被称为一个 *port*。
 
 默认情况下，Ports 本身被存储在 `/usr/ports` 的子目录中。
 


### PR DESCRIPTION
## 概要

对照英文原版校对第 4 章（安装应用程序：软件包和 Ports），修复格式问题。

## 修改详情

### 4.2 软件安装的概述
- 修复 "FreeBSD  Ports" 多余空格 ×2

### 4.4 使用 pkg 管理二进制包
- 修复 "Ports  安装软件" 和 "FreeBSD Ports  中的" 多余空格 ×2

### 4.5 使用 Ports
- 修复 "补丁和描述文件的" → "补丁和描述文件"（多余"的"字）

## 关于第 4 章

第 4 章翻译质量较高，术语准确、章节结构完整（含 4.4.3 内核模块仓库等新节）。本次仅修复格式问题，无实质性翻译错误。

## 测试计划
- [ ] 确认 markdownlint 无报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

修复第 4 章关于安装应用程序的中文翻译中的轻微格式和措辞问题，确保术语和空格使用一致。

文档：
- 修正第 4 章中文手册中 4.2 和 4.4 小节中术语 “Ports” 周围的空格。
- 优化 4.5 小节中关于什么构成 Port 的描述，删除中文文本中的一个多余字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix minor formatting and wording issues in the Chinese translation of Chapter 4 about installing applications, ensuring consistent terminology and spacing.

Documentation:
- Correct spacing around the term "Ports" in sections 4.2 and 4.4 of the Chapter 4 Chinese handbook.
- Refine the description of what constitutes a Port in section 4.5 by removing an extraneous character in the Chinese text.

</details>