### PR TITLE
fix: 修正第 5 章翻译表达问题

### DIFF
--- a/di-5-zhang-xwindow-xi-tong/5.2.-an-zhuang-xorg.md
+++ b/di-5-zhang-xwindow-xi-tong/5.2.-an-zhuang-xorg.md
@@ -2,7 +2,7 @@
 
 **摘要**：识别你的显卡，找到提供驱动的 Port，安装它，然后通过 [sysrc(8)](https://man.freebsd.org/cgi/man.cgi?query=sysrc&sektion=8&format=html) 启用，以便在后续启动时运行。
 
-在 FreeBSD 能够渲染显卡环境之前，需要内核模块来驱动显卡处理器。显卡驱动发展迅速且跨平台，因此它们是单独开发和发布的，而不随 FreeBSD 基本系统一起分发。
+在 FreeBSD 能够渲染图形环境之前，需要内核模块来驱动显卡处理器。显卡驱动发展迅速且跨平台，因此它们是单独开发和发布的，而不随 FreeBSD 基本系统一起分发。
 
 下表显示了 FreeBSD 支持的不同显卡处理器、对应的内核模块以及提供驱动的 Port：
 
@@ -18,7 +18,7 @@
 
 支持的驱动技术包括：
 
-* **直接渲染驱动）**，支持 PRIME 卸载（offload）。PRIME 能让多个显卡处理器共存。有关 PRIME 的详细说明，请参见 [显卡配置](https://docs.freebsd.org/en/books/handbook/x11/#x-config-gpu)。
+* **直接渲染驱动**，支持 PRIME 卸载（offload）。PRIME 能让多个显卡处理器共存。有关 PRIME 的详细说明，请参见 [显卡配置](https://docs.freebsd.org/en/books/handbook/x11/#x-config-gpu)。
 * **内核模式设置（KMS）**，能让驱动直接指定显示模式。使用 [vt(4)](https://man.freebsd.org/cgi/man.cgi?query=vt&sektion=4&format=html) 控制台驱动时，这对于支持挂起和恢复是必须的。
 * **用户模式设置**，这是最古老的驱动类别，仍然受到支持，但只能用于 [sc(4)](https://man.freebsd.org/cgi/man.cgi?query=sc&sektion=4&format=html) 控制台和较旧版本的 [Xorg(1)](https://man.freebsd.org/cgi/man.cgi?query=Xorg&sektion=1&format=html) 显卡环境。
 


### PR DESCRIPTION
## 概要

对照英文原版校对第 5 章（X Window 系统），修复表达问题。

## 修改详情

- 5.2: "渲染显卡环境" → "渲染图形环境"
- 5.2: 修复 "直接渲染驱动）" 多余右括号

## 关于第 5 章

第 5 章翻译质量较好，仅发现 2 处小问题。另外注意到文件命名与 SUMMARY.md 中标题存在错位（如 `5.2.-an-zhuang-xorg.md` 的实际标题为"显卡驱动"），这是项目级结构问题，建议单独处理。

## 测试计划
- [ ] 确认 markdownlint 无报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

润色 X Window System 文档第 5.2 章中的中文翻译，以提升措辞准确性并修复一个小的拼写错误。

文档：
- 通过调整术语，澄清第 5.2 章中对 FreeBSD 图形渲染环境的描述。
- 修复 X Window System 文档第 5.2 章中关于直接渲染驱动描述里的一个多余括号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish the Chinese translation in chapter 5.2 of the X Window System documentation to improve wording accuracy and fix a minor typo.

Documentation:
- Clarify the description of FreeBSD’s graphics rendering environment in chapter 5.2 by adjusting terminology.
- Fix a stray parenthesis in the description of the direct rendering driver in chapter 5.2 of the X Window System docs.

</details>