### PR TITLE
fix: 修正第 9 章翻译差异及事实错误

### DIFF
--- a/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
+++ b/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
@@ -57,12 +57,12 @@ webcamd [-d ugen1.3] -N Realtek-802-11n-WLAN-Adapter -S 00e04c000001 -M 0
 通过执行以下命令配置可用的摄像头：
 
 ```sh
-# sysrc webcamd_0_flags="-d ugen0.2" 
+# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera"
 ```
 
 >**注意**
 >
->注意，如果这是一个即插即用的 USB 摄像头，更改连接的 USB 端口将更改 `webcamd -l` 输出中的内容，并且可能需要更新 rc.conf 中的条目。对于使用 USB 集成摄像头的笔记本电脑，这通常不成问题。
+>注意，如果这是一个即插即用的 USB 摄像头，更改连接的 USB 端口将更改 `webcamd -l` 输出中的内容，并且可能需要更新 rc.conf 中的条目。为避免此问题，请使用设备名称（`-N`）或序列号（`-S`）。对于静态设备（如集成笔记本摄像头），可以使用设备标识符（`-d`）。
 
 必须通过执行以下命令启动 [webcamd(8)](https://man.freebsd.org/cgi/man.cgi?query=webcamd&sektion=8&format=html) 服务：
 
@@ -96,7 +96,7 @@ FreeBSD 当前支持以下用于进行视频会议的工具。
 | 名称              | Firefox 状态  | Chromium 状态 | 网站 |
 | ------------------- | ------------- | ------------- | ---- |
 | Microsoft Teams    | 不可用       | 可用          | [https://teams.live.com](https://teams.live.com/) |
-| Google Meet        | 不可用       | 可用          | [https://meet.google.com/](https://meet.google.com/) |
+| Google Meet        | 可用          | 可用          | [https://meet.google.com/](https://meet.google.com/) |
 | Zoom               | 可用          | 可用          | [https://zoom.us](https://zoom.us/) |
 | Jitsi              | 不可用       | 可用          | [https://meet.jit.si/](https://meet.jit.si/) |
 | BigBlueButton      | 不可用       | 可用          | [https://bigbluebutton.org/](https://bigbluebutton.org/) |


### PR DESCRIPTION
## 概要

对照英文原版逐节校对第 9 章（多媒体），修复配置差异和事实错误。

## 修改详情

### 9.5 视频会议
- **webcamd 配置命令对齐英文原版**：`-d ugen0.2` → `-N SunplusIT-Inc-HP-TrueVision-HD-Camera`（英文推荐使用设备名称避免 USB 端口变化导致的问题）
- **补充缺失说明**：添加了使用 `-N`（设备名称）或 `-S`（序列号）及 `-d`（设备标识符）的设备命名建议
- **事实错误**：Google Meet Firefox 状态"不可用"→"可用"（与英文原版一致）

## 关于第 9 章

整体翻译质量高，6 节中仅发现 9.5 节有 2 处需修正。其余各节（声卡设置、音频播放器、视频播放器、图像扫描仪）翻译准确无误。

## 测试计划
- [ ] 确认 markdownlint 无报错

## Summary by Sourcery

通过纠正摄像头配置指南和视频会议支持状态，使第 9.5 章多媒体文档与英文原文保持一致。

文档：
- 更新 `webcamd` 配置示例及其附带说明，建议通过设备名称或序列号识别设备，而不是使用依赖 USB 端口的标识符。
- 更正视频会议工具表格中 Google Meet 在 Firefox 上的支持状态，以反映当前的可用情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align chapter 9.5 multimedia documentation with the English original by correcting webcam configuration guidance and video conferencing support status.

Documentation:
- Update webcamd configuration example and accompanying note to recommend identifying devices by name or serial number instead of USB port–dependent identifiers.
- Correct Google Meet Firefox support status in the video conferencing tools table to reflect current availability.

</details>