### PR TITLE
fix: 修正第 10 章漏译及缺失内容

### DIFF
--- a/di-10-zhang-pei-zhi-freebsd-nei-he/10.5.-bian-yi-yu-an-zhuang-ding-zhi-nei-he.md
+++ b/di-10-zhang-pei-zhi-freebsd-nei-he/10.5.-bian-yi-yu-an-zhuang-ding-zhi-nei-he.md
@@ -38,4 +38,16 @@ MODULES_OVERRIDE = linux acpi
 WITHOUT_MODULES = linux acpi sound
 ```
 
+`NO_MODULES` 完全跳过模块构建，仅构建内核：
+
+```ini
+NO_MODULES = yes
+```
+
+**Ports 框架**包含依赖内核接口的驱动程序和模块（如 [graphics/drm-kmod](https://cgit.freebsd.org/ports/tree/graphics/drm-kmod/)、[emulators/virtualbox-ose-kmod](https://cgit.freebsd.org/ports/tree/emulators/virtualbox-ose-kmod/)）。使用 `PORTS_MODULES` 变量，每次内核构建时也会重新构建这些 port 并同步内核接口，确保"内核模块与内核本身保持同步"。内核树和 ports 树应一起更新。例如：
+
+```ini
+PORTS_MODULES = drm-kmod virtualbox-ose-kmod
+```
+
 还可以使用其他变量。有关详细信息，请参阅 [make.conf(5)](https://man.freebsd.org/cgi/man.cgi?query=make.conf&sektion=5&format=html)。

--- a/di-10-zhang-pei-zhi-freebsd-nei-he/10.5.-bian-yi-yu-an-zhuang-ding-zhi-nei-he.md
+++ b/di-10-zhang-pei-zhi-freebsd-nei-he/10.5.-bian-yi-yu-an-zhuang-ding-zhi-nei-he.md
@@ -44,7 +44,7 @@ WITHOUT_MODULES = linux acpi sound
 NO_MODULES = yes
 ```
 
-**Ports 框架**包含依赖内核接口的驱动程序和模块（如 [graphics/drm-kmod](https://cgit.freebsd.org/ports/tree/graphics/drm-kmod/)、[emulators/virtualbox-ose-kmod](https://cgit.freebsd.org/ports/tree/emulators/virtualbox-ose-kmod/)）。使用 `PORTS_MODULES` 变量，每次内核构建时也会重新构建这些 port 并同步内核接口，确保"内核模块与内核本身保持同步"。内核树和 ports 树应一起更新。例如：
+**Ports 框架**包含依赖内核接口的驱动程序和模块（如 [graphics/drm-kmod](https://cgit.freebsd.org/ports/tree/graphics/drm-kmod/)、[emulators/virtualbox-ose-kmod](https://cgit.freebsd.org/ports/tree/emulators/virtualbox-ose-kmod/)）。使用 `PORTS_MODULES` 变量，每次内核构建时也会重新构建这些 port 并同步内核接口，确保“内核模块与内核本身保持同步”。内核树和 ports 树应一起更新。例如：
 
 ```ini
 PORTS_MODULES = drm-kmod virtualbox-ose-kmod

--- a/di-10-zhang-pei-zhi-freebsd-nei-he/10.6.-ru-guo-fa-sheng-le-yi-xie-cuo-wu.md
+++ b/di-10-zhang-pei-zhi-freebsd-nei-he/10.6.-ru-guo-fa-sheng-le-yi-xie-cuo-wu.md
@@ -20,6 +20,10 @@ config: line 17: syntax error
 
 在使用一个可用的内核启动后，请检查配置文件并尝试重新构建。一个有用的资源是 /var/log/messages，它记录了每次成功启动的内核信息。另外，[dmesg(8)](https://man.freebsd.org/cgi/man.cgi?query=dmesg&sektion=8&format=html) 会打印当前启动的内核信息。
 
+>**技巧**
+>
+>保留一份已知可正常工作的内核副本（如 GENERIC）是个好习惯。每次安装新内核时，都会将 kernel.old 覆盖为上一次安装的内核（而它可能也无法启动）。可以通过重命名目录来恢复可正常工作的内核：
+
 ```sh
 # mv /boot/kernel /boot/kernel.bad
 # mv /boot/kernel.good /boot/kernel


### PR DESCRIPTION
## 概要

对照英文原版逐节校对第 10 章（配置 FreeBSD 内核），修复漏译和缺失内容。

## 修改详情

### 10.5 构建并安装定制内核
- **补全缺失段落**：添加了 `NO_MODULES`（完全跳过模块构建）及 `PORTS_MODULES`（Ports 框架内核模块同步）的配置说明和示例

### 10.6 如果发生了错误
- **补充缺失上下文**：为 `mv` 恢复命令添加了说明段落——解释为何需要保留已知可正常工作的内核副本，以及 kernel.old 的覆盖机制

## 关于第 10 章

其余 4 节（10.1-10.4）翻译准确，无需修改。

## 测试计划
- [ ] 确认 markdownlint 无报错

## Summary by Sourcery

更新第 10 章的中文翻译，以恢复缺失的内核配置和恢复指南内容。

Documentation:
- 在 FreeBSD 内核配置章节中记录 `NO_MODULES` 选项，用于跳过内核模块的构建。
- 描述 `PORTS_MODULES` 选项及其在保持基于 ports 的内核模块与内核同步方面的作用。
- 解释保留一份已知稳定内核副本的原因与操作步骤，以及在新内核启动失败时使用 `mv` 将其恢复的过程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Chinese translation of Chapter 10 to restore missing kernel configuration and recovery guidance content.

Documentation:
- Document the NO_MODULES option for skipping kernel module builds in the FreeBSD kernel configuration chapter.
- Describe the PORTS_MODULES option and its role in keeping ports-based kernel modules in sync with the kernel.
- Explain the rationale and procedure for preserving a known-good kernel copy and using mv to restore it when a new kernel fails.

</details>