### PR TITLE
fix: 修正第 25 章格式问题

### DIFF
--- a/di-25-zhang-ben-di-hua-i18nl10n-de-shi-yong-he-she-zhi/25.2.-shi-yong-ben-di-hua.md
+++ b/di-25-zhang-ben-di-hua-i18nl10n-de-shi-yong-he-she-zhi/25.2.-shi-yong-ben-di-hua.md
@@ -206,7 +206,7 @@ keychange="fkey_number sequence"
 | CP437 (VGA 默认)         | `cons25`   |
 | US-ASCII               | `cons25w`  |
 
-对于使用宽字符或多字节字符的语言，从 FreeBSD Ports  安装相应的控制台。可用的 Port 总结在 [来自 Ports  的可用控制台](https://docs.freebsd.org/en/books/handbook/l10n/#locale-console) 中。安装完成后，查看端口的 **pkg-message** 或 man 页面以获取配置和使用说明。
+对于使用宽字符或多字节字符的语言，从 FreeBSD Ports 安装相应的控制台。可用的 Port 总结在 [来自 Ports 的可用控制台](https://docs.freebsd.org/en/books/handbook/l10n/#locale-console) 中。安装完成后，查看端口的 **pkg-message** 或 man 页面以获取配置和使用说明。
 
 **表 3. 来自 Ports 的可用控制台**
 
@@ -229,7 +229,7 @@ mousechar_start=3
 
 [The X Window System](https://docs.freebsd.org/en/books/handbook/x11/#x11) 介绍了如何安装和配置 Xorg。在为 Xorg 配置本地化时，可以从 FreeBSD Ports 获取额外的字体和输入法。应用程序特定的国际化设置，如字体和菜单，可以在 **~/.Xresources** 文件中进行调整，允许用户在图形应用程序的菜单中查看所选语言。
 
-X 输入法（XIM）协议是 Xorg 标准，用于输入非英文字符。[可用输入法](https://docs.freebsd.org/en/books/handbook/l10n/#locale-xim) 总结了 FreeBSD Ports  中可用的输入法应用程序。额外的 Fcitx 和 Uim 应用程序也可供使用。
+X 输入法（XIM）协议是 Xorg 标准，用于输入非英文字符。[可用输入法](https://docs.freebsd.org/en/books/handbook/l10n/#locale-xim) 总结了 FreeBSD Ports 中可用的输入法应用程序。额外的 Fcitx 和 Uim 应用程序也可供使用。
 
 **表 4. 可用输入法**
 

--- a/di-25-zhang-ben-di-hua-i18nl10n-de-shi-yong-he-she-zhi/25.4.-te-ding-yu-yan-de-qu-yu-pei-zhi.md
+++ b/di-25-zhang-ben-di-hua-i18nl10n-de-shi-yong-he-she-zhi/25.4.-te-ding-yu-yan-de-qu-yu-pei-zhi.md
@@ -49,7 +49,7 @@ lp|Russian local line printer:\
 FontPath   "/usr/local/lib/X11/fonts/cyrillic"
 ```
 
-更多的西里尔字母字体可以在 Ports  中找到。
+更多的西里尔字母字体可以在 Ports 中找到。
 
 要启用俄语键盘，在 **/etc/xorg.conf** 的 `"Keyboard"` 部分中添加以下行：
 


### PR DESCRIPTION
## 概要

对照英文原版校对第 23 章（其他文件系统）、第 24 章（虚拟化）、第 25 章（本地化）、第 26 章（更新与升级）。

## 修改详情

- 25.2/25.4: 修复 3 处多余空格

第 23、24、26 章翻译准确，无需修改。

## Summary by Sourcery

通过规范围绕 FreeBSD Ports 及相关术语的空格使用，修复第 25 章本地化文档中的格式问题。

改进内容：
- 在第 25.2 节中，规范 “FreeBSD Ports” 及相关术语周围的空格，以匹配原始文档的格式。
- 在第 25.4 节中，调整 “Ports” 一词周围的空格，以确保本地化章节中的版式一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix formatting issues in chapter 25 localization documentation by normalizing spacing around references to FreeBSD Ports and related terms.

Enhancements:
- Normalize spacing around 'FreeBSD Ports' and related terms in section 25.2 to match original documentation formatting.
- Adjust spacing around 'Ports' in section 25.4 to ensure consistent typography in the localization chapter.

</details>