### PR TITLE
fix: 更新第 17 章版本号至 15.0-RELEASE

### DIFF
--- a/di-17-zhang-jail/17.4.-chuan-tong-jail-hou-jail.md
+++ b/di-17-zhang-jail/17.4.-chuan-tong-jail-hou-jail.md
@@ -11,7 +11,7 @@ jail 的用户空间可以从 FreeBSD 官方下载服务器获取。
 执行以下命令下载用户空间：
 
 ```sh
-# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/14.2-RELEASE/base.txz -o /usr/local/jails/media/14.2-RELEASE-base.txz
+# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/15.0-RELEASE/base.txz -o /usr/local/jails/media/15.0-RELEASE-base.txz
 ```
 
 下载完成后，需要将其内容解压到 jail 的目录中。
@@ -20,7 +20,7 @@ jail 的用户空间可以从 FreeBSD 官方下载服务器获取。
 
 ```sh
 # mkdir -p /usr/local/jails/containers/classic
-# tar -xf /usr/local/jails/media/14.2-RELEASE-base.txz -C /usr/local/jails/containers/classic --unlink
+# tar -xf /usr/local/jails/media/15.0-RELEASE-base.txz -C /usr/local/jails/containers/classic --unlink
 ```
 
 将用户空间解压到 jail 目录后，需要复制时区和 DNS 服务器的配置文件：

--- a/di-17-zhang-jail/17.5.-shou-jail.md
+++ b/di-17-zhang-jail/17.5.-shou-jail.md
@@ -13,32 +13,32 @@
 要为模板创建数据集，执行以下命令：
 
 ```sh
-# zfs create -p zroot/jails/templates/14.2-RELEASE
+# zfs create -p zroot/jails/templates/15.0-RELEASE
 ```
 
 然后执行以下命令下载用户空间：
 
 ```sh
-# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/14.2-RELEASE/base.txz -o /usr/local/jails/media/14.2-RELEASE-base.txz
+# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/15.0-RELEASE/base.txz -o /usr/local/jails/media/15.0-RELEASE-base.txz
 ```
 
 下载完成后，需要通过以下命令将内容解压到模板目录中：
 
 ```sh
-# tar -xf /usr/local/jails/media/14.2-RELEASE-base.txz -C /usr/local/jails/templates/14.2-RELEASE --unlink
+# tar -xf /usr/local/jails/media/15.0-RELEASE-base.txz -C /usr/local/jails/templates/15.0-RELEASE --unlink
 ```
 
 在模板目录中提取用户空间后，需要通过以下命令将时区和 DNS 服务器文件复制到模板目录中：
 
 ```sh
-# cp /etc/resolv.conf /usr/local/jails/templates/14.2-RELEASE/etc/resolv.conf
-# cp /etc/localtime /usr/local/jails/templates/14.2-RELEASE/etc/localtime
+# cp /etc/resolv.conf /usr/local/jails/templates/15.0-RELEASE/etc/resolv.conf
+# cp /etc/localtime /usr/local/jails/templates/15.0-RELEASE/etc/localtime
 ```
 
 接下来的步骤是通过执行以下命令更新到最新的补丁级别：
 
 ```sh
-# freebsd-update -b /usr/local/jails/templates/14.2-RELEASE/ fetch install
+# freebsd-update -b /usr/local/jails/templates/15.0-RELEASE/ fetch install
 ```
 
 更新完成后，模板就准备好了。
@@ -46,7 +46,7 @@
 要从模板创建 OpenZFS 快照，执行以下命令：
 
 ```sh
-# zfs snapshot zroot/jails/templates/14.2-RELEASE@base
+# zfs snapshot zroot/jails/templates/15.0-RELEASE@base
 ```
 
 待创建了 OpenZFS 快照，就可以使用 OpenZFS 克隆功能创建无限多个 jail。
@@ -54,7 +54,7 @@
 要创建一个名为 `thinjail` 的瘦 jail，执行以下命令：
 
 ```sh
-# zfs clone zroot/jails/templates/14.2-RELEASE@base zroot/jails/containers/thinjail
+# zfs clone zroot/jails/templates/15.0-RELEASE@base zroot/jails/containers/thinjail
 ```
 
 最后一步是配置 jail。需要在 **/etc/jail.conf** 或 **jail.conf.d** 配置文件中添加该 jail 的条目。
@@ -98,38 +98,38 @@ thinjail {
 第一步是创建用于保存模板的数据集。如果使用 OpenZFS，请执行以下命令：
 
 ```sh
-# zfs create -p zroot/jails/templates/14.2-RELEASE-base
+# zfs create -p zroot/jails/templates/15.0-RELEASE-base
 ```
 
 如果使用 UFS，请执行以下命令：
 
 ```sh
-# mkdir /usr/local/jails/templates/14.2-RELEASE-base
+# mkdir /usr/local/jails/templates/15.0-RELEASE-base
 ```
 
 然后执行以下命令下载用户空间：
 
 ```sh
-# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/14.2-RELEASE/base.txz -o /usr/local/jails/media/14.2-RELEASE-base.txz
+# fetch https://download.freebsd.org/ftp/releases/amd64/amd64/15.0-RELEASE/base.txz -o /usr/local/jails/media/15.0-RELEASE-base.txz
 ```
 
 下载完成后，需要通过以下命令将内容解压到模板目录中：
 
 ```sh
-# tar -xf /usr/local/jails/media/14.2-RELEASE-base.txz -C /usr/local/jails/templates/14.2-RELEASE-base --unlink
+# tar -xf /usr/local/jails/media/15.0-RELEASE-base.txz -C /usr/local/jails/templates/15.0-RELEASE-base --unlink
 ```
 
 待用户空间提取到模板目录中，就需要通过以下命令将时区和 DNS 服务器文件复制到模板目录中：
 
 ```sh
-# cp /etc/resolv.conf /usr/local/jails/templates/14.2-RELEASE-base/etc/resolv.conf
-# cp /etc/localtime /usr/local/jails/templates/14.2-RELEASE-base/etc/localtime
+# cp /etc/resolv.conf /usr/local/jails/templates/15.0-RELEASE-base/etc/resolv.conf
+# cp /etc/localtime /usr/local/jails/templates/15.0-RELEASE-base/etc/localtime
 ```
 
 将文件移动到模板中后，接下来的步骤是通过以下命令更新到最新的补丁级别：
 
 ```sh
-# freebsd-update -b /usr/local/jails/templates/14.2-RELEASE-base/ fetch install
+# freebsd-update -b /usr/local/jails/templates/15.0-RELEASE-base/ fetch install
 ```
 
 除了基础模板外，还需要创建一个目录来存放 `skeleton`。一些目录将从模板复制到 `skeleton` 中。
@@ -137,13 +137,13 @@ thinjail {
 如果使用 OpenZFS，请执行以下命令来创建 `skeleton` 的数据集：
 
 ```sh
-# zfs create -p zroot/jails/templates/14.2-RELEASE-skeleton
+# zfs create -p zroot/jails/templates/15.0-RELEASE-skeleton
 ```
 
 如果使用 UFS，请执行以下命令：
 
 ```sh
-# mkdir /usr/local/jails/templates/14.2-RELEASE-skeleton
+# mkdir /usr/local/jails/templates/15.0-RELEASE-skeleton
 ```
 
 然后创建 `skeleton` 目录。`skeleton` 目录将存放 jail 的本地目录。
@@ -151,19 +151,19 @@ thinjail {
 执行以下命令创建这些目录：
 
 ```sh
-# mkdir -p /usr/local/jails/templates/14.2-RELEASE-skeleton/home
-# mkdir -p /usr/local/jails/templates/14.2-RELEASE-skeleton/usr
-# mv /usr/local/jails/templates/14.2-RELEASE-base/etc /usr/local/jails/templates/14.2-RELEASE-skeleton/etc
-# mv /usr/local/jails/templates/14.2-RELEASE-base/usr/local /usr/local/jails/templates/14.2-RELEASE-skeleton/usr/local
-# mv /usr/local/jails/templates/14.2-RELEASE-base/tmp /usr/local/jails/templates/14.2-RELEASE-skeleton/tmp
-# mv /usr/local/jails/templates/14.2-RELEASE-base/var /usr/local/jails/templates/14.2-RELEASE-skeleton/var
-# mv /usr/local/jails/templates/14.2-RELEASE-base/root /usr/local/jails/templates/14.2-RELEASE-skeleton/root
+# mkdir -p /usr/local/jails/templates/15.0-RELEASE-skeleton/home
+# mkdir -p /usr/local/jails/templates/15.0-RELEASE-skeleton/usr
+# mv /usr/local/jails/templates/15.0-RELEASE-base/etc /usr/local/jails/templates/15.0-RELEASE-skeleton/etc
+# mv /usr/local/jails/templates/15.0-RELEASE-base/usr/local /usr/local/jails/templates/15.0-RELEASE-skeleton/usr/local
+# mv /usr/local/jails/templates/15.0-RELEASE-base/tmp /usr/local/jails/templates/15.0-RELEASE-skeleton/tmp
+# mv /usr/local/jails/templates/15.0-RELEASE-base/var /usr/local/jails/templates/15.0-RELEASE-skeleton/var
+# mv /usr/local/jails/templates/15.0-RELEASE-base/root /usr/local/jails/templates/15.0-RELEASE-skeleton/root
 ```
 
 接下来的步骤是通过执行以下命令创建指向 `skeleton` 的符号链接：
 
 ```sh
-# cd /usr/local/jails/templates/14.2-RELEASE-base/
+# cd /usr/local/jails/templates/15.0-RELEASE-base/
 # mkdir skeleton
 # ln -s skeleton/etc etc
 # ln -s skeleton/home home
@@ -178,14 +178,14 @@ thinjail {
 如果使用 OpenZFS，可以使用 OpenZFS 快照轻松创建所需数量的 jail，执行以下命令：
 
 ```sh
-# zfs snapshot zroot/jails/templates/14.2-RELEASE-skeleton@base
-# zfs clone zroot/jails/templates/14.2-RELEASE-skeleton@base zroot/jails/containers/thinjail
+# zfs snapshot zroot/jails/templates/15.0-RELEASE-skeleton@base
+# zfs clone zroot/jails/templates/15.0-RELEASE-skeleton@base zroot/jails/containers/thinjail
 ```
 
 如果使用 UFS，可以使用 [cp(1)](https://man.freebsd.org/cgi/man.cgi?query=cp&sektion=1&format=html) 程序，执行以下命令：
 
 ```sh
-# cp -R /usr/local/jails/templates/14.2-RELEASE-skeleton /usr/local/jails/containers/thinjail
+# cp -R /usr/local/jails/templates/15.0-RELEASE-skeleton /usr/local/jails/containers/thinjail
 ```
 
 然后创建一个目录，用于挂载基础模板和 skeleton：
@@ -224,7 +224,7 @@ thinjail {
 然后创建 **/usr/local/jails/thinjail-nullfs-base.fstab** 文件，内容如下：
 
 ```sh
-/usr/local/jails/templates/14.2-RELEASE-base  /usr/local/jails/thinjail-nullfs-base/ nullfs   ro          0 0
+/usr/local/jails/templates/15.0-RELEASE-base  /usr/local/jails/thinjail-nullfs-base/ nullfs   ro          0 0
 /usr/local/jails/containers/thinjail     /usr/local/jails/thinjail-nullfs-base/skeleton nullfs  rw  0 0
 ```
 


### PR DESCRIPTION
## 概要

逐节对照英文原版校对第 17 章（Jail 和容器）。

## 修改详情

- 17.4/17.5: 下载 URL 和 ZFS 模板版本号 14.2-RELEASE→15.0-RELEASE（共 31 处）
- 其余各节（17.1-17.3、17.6-17.9）翻译准确、结构完整

## Summary by Sourcery

文档：
- 更新第 17.4 和 17.5 节中的 jail 和容器设置示例，将其中的路径、URL 和数据集名称从 14.2-RELEASE 替换为 15.0-RELEASE。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh jail and container setup examples in sections 17.4 and 17.5 to use 15.0-RELEASE paths, URLs, and dataset names instead of 14.2-RELEASE.

</details>