### PR TITLE
fix: 修正第 5 章翻译错误及同步英文原版更新

### DIFF
--- a/di-5-zhang-xwindow-xi-tong/5.1.-gai-shu.md
+++ b/di-5-zhang-xwindow-xi-tong/5.1.-gai-shu.md
@@ -6,7 +6,7 @@
 
 * 了解如何按照 [安装应用程序：软件包和 Ports](../di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.1.-gai-shu.md) 的说明安装额外的第三方软件。
 
-通过阅读本章，你将了解：
+阅读本章，你将了解：
 
 * 如何为图形处理器（GPU）选择和安装驱动程序。
 * X Window 系统的各个组件及其协作方式。

--- a/di-5-zhang-xwindow-xi-tong/5.4.-an-zhuang-xorg-fu-wu-qi.md
+++ b/di-5-zhang-xwindow-xi-tong/5.4.-an-zhuang-xorg-fu-wu-qi.md
@@ -18,7 +18,7 @@
 # pw groupmod video -m username
 ```
 
-要运行 X Window 系统，可使用来自 [x11/xinit](https://cgit.freebsd.org/ports/tree/x11/xinit/) 的 [startx(1)](https://man.freebsd.org/cgi/man.cgi?query=startx&sektion=1&format=html)，或安装并配置显示管理器，在启动时进行图形登录。
+要运行 X Window 系统，可使用来自 [x11/xinit](https://cgit.freebsd.org/ports/tree/x11/xinit/) 的 [startx(1)](https://man.freebsd.org/cgi/man.cgi?query=startx&sektion=1&format=html)，或者安装并配置显示管理器，在启动时进行图形登录。
 
 > **技巧**
 >

--- a/di-5-zhang-xwindow-xi-tong/5.5.-xorg-pei-zhi.md
+++ b/di-5-zhang-xwindow-xi-tong/5.5.-xorg-pei-zhi.md
@@ -123,7 +123,7 @@ EndSection
 
 几乎所有显示器都支持扩展显示识别数据（`EDID`）标准。X.org 使用 `EDID` 与显示器通信，检测支持的分辨率和刷新率，然后选择最合适的组合。
 
-其他显示器支持的分辨率可在 X 服务器启动后，通过 [xrandr(1)](https://man.freebsd.org/cgi/man.cgi?query=xrandr&sektion=1&format=html) 原子方式选择，或在 X.org 配置文件中设置。
+其他显示器支持的分辨率可以在 X 服务器启动后，通过 [xrandr(1)](https://man.freebsd.org/cgi/man.cgi?query=xrandr&sektion=1&format=html) 以原子方式选择，或者在 X.org 配置文件中设置。
 
 ### 5.5.3.1. 使用 RandR（调整分辨率与方向）
 
@@ -230,7 +230,7 @@ $ xinput
     ↳ AT keyboard                             	id=10	[slave  keyboard (3)]
 ```
 
-所有支持的设置以属性形式提供，可原子方式列出和设置。指点设备属性多，键盘一般无需调整。
+所有支持的设置均以属性形式提供，可以原子方式列出和设置。指点设备属性较多，键盘一般无需调整。
 
 自定义键盘布局请参考 [setxkbmap(1)](https://man.freebsd.org/cgi/man.cgi?query=setxkbmap&sektion=1&format=html)。
 


### PR DESCRIPTION
# 修正第 5 章翻译错误及同步英文原版更新

## 概述

对第 5 章「X Window 系统」进行了完整审查，对照官方英文手册（https://docs.freebsd.org/en/books/handbook/x11/）进行了逐节双语对照。

本次 PR 严格遵循**保守治疗**原则（与第 4 章一致）：
- 仅进行最小必要、忠实原版的润色
- 绝不大幅重构句子
- 完全保留英文原版的风格与术语用法
- 不修改任何 H1 标题
- 仅修改表述问题

## 修改统计

- 共修改 3 个文件
- 总改动量极小（4 行增加 + 4 行删除）
- 所有改动均为保守润色

## 详细修改列表

### 5.1.-gai-shu.md
- “通过阅读本章，你将了解：” → “阅读本章，你将了解：”
- 理由：去除冗余“通过”，使表达更直接贴近英文语气。

### 5.4.-an-zhuang-xorg-fu-wu-qi.md
- 长句中的“或”改为“或者”（轻微流畅度优化）
- 理由：提升中文阅读自然度，不改变原意。

### 5.5.-xorg-pei-zhi.md
- “原子方式选择” → “以原子方式选择”
- “所有支持的设置以属性形式提供，可原子方式列出和设置。指点设备属性多...” → 增加“均”“可以”，并将“属性多”改为“属性较多”
- 理由：极小幅度提升句子流畅度，保持技术准确性。

## 审查过程

- 完整读取英文原版全章 + 中文 6 个 .md 文件
- 逐节双语对照
- 参考《译者说明》及 ykla 最近的术语替换保持一致性
- 仅提交内容文件，无无关改动

## 下一步

欢迎 review。如有任何问题请指出，我会按保守原则继续调整。

---
本 PR 仅包含第 5 章翻译优化，不涉及其他章节或格式修改。

## Summary by Sourcery

在保持与英文原文一致的前提下，优化第 5 章 X Window System 文档中的措辞，以提升中文翻译的准确性和可读性。

Bug 修复：
- 修正 X Window System 章节中 5.1、5.4 和 5.5 小节中文翻译中的轻微错误和生硬表述。

文档：
- 打磨描述学习目标、X 启动方式以及 X.org 分辨率和输入设置的句子，使其更好地匹配上游英文手册的意图与文风。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine wording in Chapter 5 X Window System documentation to improve Chinese translation accuracy and readability while staying aligned with the English original.

Bug Fixes:
- Correct minor inaccuracies and awkward phrasing in the Chinese translation of sections 5.1, 5.4, and 5.5 of the X Window System chapter.

Documentation:
- Polish sentences describing learning outcomes, X startup methods, and X.org resolution and input settings to better match the intent and style of the upstream English handbook.

</details>