### PR TITLE
fix: 修正第 4 章翻译错误及同步英文原版更新

### DIFF
--- a/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.4.-shi-yong-pkg-jin-hang-er-jin-zhi-bao-guan-li.md
+++ b/di-4-zhang-an-zhuang-ying-yong-cheng-xu-ruan-jian-bao-he-ports/4.4.-shi-yong-pkg-jin-hang-er-jin-zhi-bao-guan-li.md
@@ -80,10 +80,8 @@ FreeBSD-kmods: {
 
 例如：
 
-Kmodsflavor
-
+| FreeBSD 版本 | ports main | ports 季度分支 |
 | :---: | :---: | :---: |
-| **FreeBSD 版本** | **ports main** | **ports 季度分支** |
 | FreeBSD 14.2-RELEASE | kmods\_latest\_2 | kmods\_quarterly\_2 |
 | FreeBSD 14.3-RELEASE | kmods\_latest\_3 | kmods\_quarterly\_3 |
 | FreeBSD 14.3-STABLE | kmods\_latest | kmods\_quarterly |


### PR DESCRIPTION
对照英文原版逐句校对第 4 章翻译。修复 4.4.3 内核模块仓库表格缺少表头行的问题，将孤立的 Kmodsflavor 文字和缺少表头的表格修复为标准 Markdown 表格格式。

## 由 Sourcery 提供的总结

文档：
- 通过添加缺失的表头行并将其转换为规范的 Markdown 表格，修正第 4.4.3 章中的内核模块仓库表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the kernel modules repository table in chapter 4.4.3 by adding the missing header row and converting it into a proper Markdown table.

</details>