### PR TITLE
fix: 修正第 5 章 NVIDIA 配置示例错误

### DIFF
--- a/di-5-zhang-xwindow-xi-tong/5.5.-xorg-pei-zhi.md
+++ b/di-5-zhang-xwindow-xi-tong/5.5.-xorg-pei-zhi.md
@@ -51,7 +51,7 @@ EndSection
 ```sh
 Section "Device"
 	Identifier "Card0"
-	Driver     "nvidia"
+	Driver     "nvidia-modeset"
 EndSection
 ```
 
@@ -114,8 +114,8 @@ EndSection
 
 Section "Device"
 	Identifier "Card1"
-	Driver     "nvidia"
-	BusID     "pci0:1:0:0"
+	Driver     "nvidia-modeset"
+	BusID     "pci0:0:2:1"
 EndSection
 ```
 


### PR DESCRIPTION
对照英文原版校对第5章，修正5.5.2中NVIDIA配置示例的Driver值和BusID值与英文原版不一致的问题。示例3: Driver nvidia改为nvidia-modeset。示例6: Card1 Driver nvidia改为nvidia-modeset，BusID pci0:1:0:0改为pci0:0:2:1。涉及文件: di-5-zhang-xwindow-xi-tong/5.5.-xorg-pei-zhi.md

## 由 Sourcery 提供的摘要

更正第 5 章 Xorg 配置文档中的 NVIDIA 配置示例，使其与英文原版保持一致。

文档：
- 在第 5 章文档中相关的 Xorg 配置示例里，将 NVIDIA Driver 的值从 `nvidia` 更新为 `nvidia-modeset`。
- 更正第 5 章文档中第二个 NVIDIA 设备示例的 `BusID` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct NVIDIA configuration examples in chapter 5 Xorg configuration documentation to match the original English version.

Documentation:
- Update NVIDIA Driver value from nvidia to nvidia-modeset in the relevant Xorg configuration examples in chapter 5 documentation.
- Correct the BusID value for the second NVIDIA device example in chapter 5 documentation.

</details>