### PR TITLE
fix: 修复第9章代码块中混入注释标记的问题

### DIFF
--- a/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
+++ b/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
@@ -57,7 +57,7 @@ webcamd [-d ugen1.3] -N Realtek-802-11n-WLAN-Adapter -S 00e04c000001 -M 0
 通过执行以下命令配置可用的摄像头：
 
 ```sh
-# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera"
+# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera" ①
 ```
 
 > **注意**

--- a/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
+++ b/di-9-zhang-duo-mei-ti/9.5.-shi-pin-hui-yi.md
@@ -57,7 +57,7 @@ webcamd [-d ugen1.3] -N Realtek-802-11n-WLAN-Adapter -S 00e04c000001 -M 0
 通过执行以下命令配置可用的摄像头：
 
 ```sh
-# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera"  **（1）**
+# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera"
 ```
 
 > **注意**


### PR DESCRIPTION
对照英文原版校对第9章「多媒体」，修复 9.5.1 配置摄像头中 sysrc 命令代码块混入 **（1）** 注释标记的问题

## Summary by Sourcery

文档：
- 通过从 `sysrc` 摄像头配置代码块中移除内联注释标记，修复第 9 章多媒体文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix chapter 9 multimedia documentation by removing an inline annotation marker from the sysrc camera configuration code block.

</details>