### PR TITLE
fix(chapter-24): 修正第 24 章翻译错误

### DIFF
--- a/di-24-zhang-xu-ni-hua/24.6.-qemu.md
+++ b/di-24-zhang-xu-ni-hua/24.6.-qemu.md
@@ -155,8 +155,9 @@ QEMU 将在一个单独的窗口中引导虚拟机，并按 [图 2](./24.6.-qemu
 以 `root` 用户登录并按以下方式更新系统：
 
 ```sh
-# freebsd-update fetch install
-# reboot
+# freebsd-update fetch
+# freebsd-update install
+# shutdown -r now
 ```
 
 > **注意**


### PR DESCRIPTION
第 24 章（虚拟化）翻译校对，修复以下问题：

1. 修正 24.6 QEMU 中 freebsd-update 命令错误（拆分为两条独立命令）

## Summary by Sourcery

Bug Fixes:
- 通过将获取和安装拆分为两个独立命令，并使用正确的重启命令，修复第 24.6 章中 FreeBSD 更新命令序列的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the FreeBSD update command sequence in chapter 24.6 by separating fetch and install into distinct commands and using the proper reboot command.

</details>