### PR TITLE
fix(chapter-26): 修正第 26 章翻译错误

### DIFF
--- a/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.2.-geng-xin-freebsd.md
+++ b/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.2.-geng-xin-freebsd.md
@@ -112,7 +112,7 @@ Uninstalling updates... done.
 
 * 从 FreeBSD 13.1 升级到 13.2。
 
-* *大版本* 升级会增加主版本号。例如：
+*大版本* 升级会增加主版本号。例如：
 
 * 从 FreeBSD 13.2 升级到 14.0。
 
@@ -230,8 +230,8 @@ before running "/usr/sbin/freebsd-update install"
 如果已构建了多次定制内核，或者不知道定制内核构建了多少次，则需要获取与当前操作系统版本匹配的 `GENERIC` 内核副本。如果可以物理访问系统，可以从安装介质安装 `GENERIC` 内核：
 
 ```sh
-# mount /cdrom
-# cd /cdrom/usr/freebsd-dist
+# mount /media
+# cd /media/usr/freebsd-dist
 # tar -C/ -xvf kernel.txz boot/kernel/kernel
 ```
 

--- a/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.6.-cong-yuan-dai-ma-geng-xin-freebsd.md
+++ b/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.6.-cong-yuan-dai-ma-geng-xin-freebsd.md
@@ -80,7 +80,7 @@ origin  https://git.freebsd.org/src.git (push)
 | uname ‑r 输出 | 仓库路径 | 说明 |
 | ------------- | -------- | ---- |
 | `X.Y-RELEASE` | `releng/X.Y` | 发布版本，仅包含关键的安全和错误修复补丁。该分支推荐给大多数用户。 |
-| `X.Y-STABLE` | `stable/X` | 发布版本加该分支的所有开发更新。*STABLE* 指的是应用二进制接口（ABI）不发生变化，因此早期版本编译的软件仍然可以在 FreeBSD 10-STABLE 上运行。例如，编译并运行在 FreeBSD 10.1 上的软件仍可以在后续的 FreeBSD 10-STABLE 上运行。STABLE 分支偶尔会有影响用户的错误或不兼容情况，但通常这些问题会迅速修复。 |
+| `X.Y-STABLE` | `stable/X` | 发布版本及该分支的所有后续开发更新。*STABLE* 指的是应用二进制接口（ABI）不发生变化，因此早期版本编译的软件仍然可以在 FreeBSD 10-STABLE 上运行。例如，编译并运行在 FreeBSD 10.1 上的软件仍可以在后续的 FreeBSD 10-STABLE 上运行。STABLE 分支偶尔会有影响用户的错误或不兼容情况，但通常这些问题会迅速修复。 |
 | `X-CURRENT` | `main` | FreeBSD 最新的未发布开发版本。CURRENT 分支可能包含重大错误或不兼容，推荐仅供专业用户使用。 |
 
 使用 [uname(1)](https://man.freebsd.org/cgi/man.cgi?query=uname&sektion=1&format=html) 确定正在使用的 FreeBSD 版本：

--- a/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.7.-pkgbase.md
+++ b/di-26-zhang-freebsd-geng-xin-yu-sheng-ji/26.7.-pkgbase.md
@@ -233,7 +233,7 @@ Ignore the mismatch and continue? [y/N]:
 # pkg unlock pkg
 ```
 
-在升级到新的 major 版本之后，可能需要更新并升级已安装的软件包，使之与 ABI 版本匹配。
+在升级到新的大版本之后，可能需要更新并升级已安装的软件包，使之与 ABI 版本匹配。
 
 ```sh
 # pkg upgrade


### PR DESCRIPTION
第 26 章（FreeBSD 更新与升级）翻译校对，修复以下问题：

1. 修复格式错误：大版本定义不应作为列表项
2. 修复事实性错误：/cdrom -> /media（与英文原版一致）
3. 修复中英文混用：major -> 大版本
4. 改善措辞：发布版本加 -> 发布版本及

注：关于删除内容的建议（问题4、6、7、8）需人工核实英文原版后再决定。

## Summary by Sourcery

润色 FreeBSD 更新与升级章节的中文翻译，使术语、格式和路径与上游英文文档保持一致。

Bug Fixes:
- 将内核安装说明中的挂载路径从 `/cdrom` 更正为 `/media`，以与原始文档保持一致。

Enhancements:
- 统一主版本升级和 ABI 相关说明的中文表述，使用一致的术语，并移除一条不正确的列表条目。
- 改进分支概览表中的措辞，更准确地描述 STABLE 版本为包含后续开发更新的发布分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish the Chinese translation of the FreeBSD update and upgrade chapter to align terminology, formatting, and paths with the upstream English documentation.

Bug Fixes:
- Correct the mount path in kernel installation instructions from /cdrom to /media to match the original documentation.

Enhancements:
- Normalize the description of major version upgrades and ABI-related guidance by using consistent Chinese terminology and removing an incorrect list bullet.
- Improve wording in the branch overview table to better describe STABLE releases as including subsequent development updates.

</details>